### PR TITLE
BAU: Tick the use use_exact_comparison_type checkbox by default

### DIFF
--- a/app/views/idp/init.html.erb
+++ b/app/views/idp/init.html.erb
@@ -55,7 +55,7 @@
 
     <div class="form-group">
       <div class="multiple-choice">
-        <%= f.check_box :use_exact_comparison_type %>
+        <%= f.check_box :use_exact_comparison_type, checked: true %>
         <%= f.label :use_exact_comparison_type, 'Use exact comparison in AuthnRequest', for: :use_exact_comparison_type %>
       </div>
       <details>


### PR DESCRIPTION
IDPs should be able to accept SAML AuthnRequests with an exact
comparison type. The option to not use that comparison type only exists
for backwards compatibility with legacy IDPs. By default, IDPs testing
new journeys (such as LOA1) should be using this comparison type.

Author: @vixus0