### PR TITLE
261: use content appropriate for an IDP

### DIFF
--- a/app/views/idp/init.html.erb
+++ b/app/views/idp/init.html.erb
@@ -4,17 +4,17 @@
 <%= form_for @init_form do |f| %>
 
     <div class="form-group">
-      <%= f.label :service_url, 'Service URL', class: 'form-label' %>
-      <span class="form-hint">This will consume responses from the GOV.UK Verify hub</span>
+      <%= f.label :service_url, 'Single Signon URL', class: 'form-label' %>
+      <span class="form-hint">This is the URL that the Compliance Tool will send SAML AuthnRequests to</span>
       <%= f.text_field :service_url, class: 'form-control' %>
       <% unless @init_form.errors[:service_url].empty? %>
-          <div class="form-error">Service URL should be a URL (e.g. https://my-service.gov.uk/SAML2/Response)</div>
+          <div class="form-error">Single Signon URL should be a URL (e.g. https://my-idp-service.co.uk/SAML2 or http://localhost:8080/SAML2)</div>
       <% end %>
       <details>
-        <summary>More about Service URL</summary>
+        <summary>More about Single Signon URL</summary>
         <div class="panel panel-border-narrow">
-          <p>In SAML speak this is your <code>AssertionConsumerService Location</code>, it's the URL the compliance tool
-            will POST the SAML Response to.</p>
+          <p>In SAML this is your <code>SingleSignonLocation</code>, it's the URL the Compliance Tool
+            will POST the SAML AuthnRequest to.</p>
         </div>
       </details>
     </div>
@@ -39,8 +39,8 @@
     </div>
 
     <div class="form-group">
-      <%= f.label :public_cert_file, 'Public Certificate', class: 'form-label' %>
-      <span class="form-hint">The certificate used to sign our AuthnRequest to you. Upload a certificate file in PEM format</span>
+      <%= f.label :public_cert_file, 'Public Signing Certificate', class: 'form-label' %>
+      <span class="form-hint">The certificate used to verify your SAML Responses. Upload a certificate file in PEM format</span>
       <%= f.file_field :public_cert_file %>
       <% unless @init_form.errors[:public_cert_file].empty? %>
           <div class="form-error">Please provide an X509 certificate in PEM format.</div>
@@ -48,7 +48,7 @@
       <details>
         <summary>More about the public certificate</summary>
         <div class="panel panel-border-narrow">
-          <p>You should have the corresponding private key so you can verify the signature.</p>
+          <p>Your service should sign with the associated private key so we can verify your signature.</p>
         </div>
       </details>
     </div>


### PR DESCRIPTION
- Replace references to AssertionConsumerUrls to Single Signon Urls
- Replace references to SAML Responses to AuthnRequests
- Use correct guidnace for use of signing certificate